### PR TITLE
Silent logout

### DIFF
--- a/src/events/NavUpdater.ts
+++ b/src/events/NavUpdater.ts
@@ -1,7 +1,7 @@
 function logOut(): void {
 	sessionStorage.clear();
 	document.cookie = 'bearer=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-	location.reload();
+	document.location.href="/";
 }
 
 function onGenericPageLoad(): void {


### PR DESCRIPTION
When a user logged out they stayed on the same page, now the session cookie is deleted and the user is redirected to the home page.