### PR TITLE
Add handling of 401, cookie expiry and challenge cleanup

### DIFF
--- a/src/controllers/LoginController.ts
+++ b/src/controllers/LoginController.ts
@@ -16,7 +16,7 @@ export class LoginController {
     }
 
     @Get("/challenge")
-    async getChallenge(@QueryParam("username") userName: string): Promise<string> {
+    async getChallenge(@QueryParam("username") userName: string): Promise<object> {
         const user = await Container.get(UserService).findOne(userName);
         if (user == null) {
             throw new BadRequestError("Cannot find User!");

--- a/src/events/LoginScript.ts
+++ b/src/events/LoginScript.ts
@@ -25,13 +25,12 @@ async function doLoginAction(event: Event): Promise<void> {
         }
         return;
     }
+    const data = await resp.json();
 
-    const challenge = await resp.text();
-
-    const result = sign(challenge, derivationResult.privateKey);
+    const result = sign(data.challenge, derivationResult.privateKey);
 
     const bearerStr = window.btoa(userName + ":" + result);
-    document.cookie = `bearer=${bearerStr};path=/;max-age=840;samesite=strict`;
+    document.cookie = `bearer=${bearerStr};path=/;max-age=${Math.round(data.expiresIn/1000)};samesite=strict`;
 
     resp = await fetch("/api/login/validate");
     if (resp.status !== 200) {

--- a/src/events/NavUpdater.ts
+++ b/src/events/NavUpdater.ts
@@ -1,3 +1,17 @@
+const originalFetch = window.fetch;
+
+window.fetch = async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+	const resp = await originalFetch(input, init);
+
+	if (resp.status === 401 && document.location.pathname !== "/login") {
+		sessionStorage.clear();
+		alert("Your session has expired! Click OK to be redirected to the login page.");
+		document.location.href="/login";
+	}
+
+	return resp;
+};
+
 function logOut(): void {
 	sessionStorage.clear();
 	document.cookie = 'bearer=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,11 +35,14 @@ const xrpConnection = setInterval(function() {
     }
 }, 5000);
 
-// run express application when database has connected succesfully
+// run express application when database has connected successfully
 setupTypeORM().then(() => {
     setupExpressApp(logger);
+    setInterval(async () => {
+        const repo = await Container.get(ChallengeRepository);
+        await repo.cleanChallenges();
+    }, 6*1000);
 }).catch((e) => {
-    setInterval(Container.get(ChallengeRepository).cleanChallenges, 60*1000);
     logger.error("Database connection failed, exiting application...");
     logger.error(e);
     process.exit(0);

--- a/src/repositories/ChallengeRepository.ts
+++ b/src/repositories/ChallengeRepository.ts
@@ -10,8 +10,9 @@ export class ChallengeRepository extends Repository<Challenge>  {
     
     log = Container.get(LoggerService);
     expireTime = Number(process.env.SESSION_EXPIRY_IN_MINUTES) * 60000;
+    frontendTimeMargin = 10 * 1000;
 
-    public async createChallenge(user: User): Promise<string> {
+    public async createChallenge(user: User): Promise<object> {
         const challenge = new Challenge();
         challenge.user = user;
         challenge.challenge = randomBytes(32).toString("hex");
@@ -19,7 +20,10 @@ export class ChallengeRepository extends Repository<Challenge>  {
 
         await getRepository(Challenge).save(challenge);
 
-        return challenge.challenge;
+        return {
+            challenge: challenge.challenge,
+            expiresIn: this.expireTime - this.frontendTimeMargin
+        };
     }
 
     public async getChallenges(user: User): Promise<Challenge[]> {


### PR DESCRIPTION
Closes #63 

- Fixed cleanChallenges not working because of an `undefined` `this`
- Cookie expiry is now linked to the `.env` `SESSION_EXPIRY` variable, such that if you change the `SESSION_EXPIRY`, the cookie `max-age` will now also be updated
- I intercepted all fetch requests to catch the 401 error, such that the user is alerted and gets redirected to the login page after pressing OK.