### PR TITLE
Implement groups on back-end

### DIFF
--- a/src/controllers/GroupController.ts
+++ b/src/controllers/GroupController.ts
@@ -143,4 +143,18 @@ export class GroupController {
         }
         return Container.get(GroupService).addParticipant(id, userId);
     }
+
+    @Authorized()
+    @Put("/:id/settle")
+    async settleGroup(@CurrentUser() user: User, @Param("id") id: string): Promise<Group> {
+        const groupService = Container.get(GroupService);
+        const group = await groupService.findOne(id);
+        
+        // Check if person trying to settle is member of group
+        const index = group.participants.findIndex(participant => participant.username === user.username);
+        if (index === -1) {
+            throw new UnauthorizedError("You are not a participant of this group");
+        }
+        return Container.get(GroupService).settleGroup(id);
+    }
 }

--- a/src/controllers/GroupController.ts
+++ b/src/controllers/GroupController.ts
@@ -1,10 +1,40 @@
 import Container from "typedi";
-import {JsonController, Get, CurrentUser, Authorized, Post, Body, Put, Param, UnauthorizedError} from "routing-controllers";
+import {JsonController, Get, CurrentUser, Authorized, Post, Body, Put, Param, UnauthorizedError, BadRequestError} from "routing-controllers";
 import { Bill } from "../models/Bill";
 import { User } from "../models/User";
 import { LoggerService } from "../services/LoggerService";
 import { Group } from "../models/Group";
 import { GroupService } from "../services/GroupService";
+import { IsString, IsNotEmpty, MaxLength, ArrayNotEmpty } from "class-validator";
+import { AddBillRequest } from "./BillController";
+import { BillWeight } from "../models/BillWeight";
+
+export class AddGroupRequest {
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(1000)
+    name: string;
+    
+    @IsString()
+    @MaxLength(1000)
+    description?: string;
+
+    @ArrayNotEmpty()
+    @IsString({each: true})
+    @MaxLength(1000, {each: true})
+    participants: string[];
+}
+
+export class UpdateGroupRequest {
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(1000)
+    name: string;
+    
+    @IsString()
+    @MaxLength(1000)
+    description: string;
+}
 
 @JsonController("/api/groups")
 export class GroupController {
@@ -18,15 +48,27 @@ export class GroupController {
     }
 
     @Authorized()
+    @Get("/:id")
+    async getGroup(@CurrentUser() user: User, @Param("id") id: string): Promise<Group> {
+        const group = await Container.get(GroupService).findOne(id);
+        // Check if person trying to get is member of group
+        const index = group.participants.findIndex(participant => participant.username === user.username);
+        if (index === -1) {
+            throw new UnauthorizedError("You are not a participant of this group");
+        }
+        return group;
+    }
+
+    @Authorized()
     @Post("/")
-    createGroup(@CurrentUser() user: User, @Body() body: Group): Promise<Group> {
+    createGroup(@CurrentUser() user: User, @Body() body: AddGroupRequest): Promise<Group> {
         const group = new Group();
         group.description = body.description;
         group.name = body.name;
         group.participants = [];
-        body.participants.forEach((user: User) => {
+        body.participants.forEach(username => {
             const part = new User();
-            part.username = user.username;
+            part.username = username;
             group.participants.push(part);
         });
         return Container.get(GroupService).create(group);
@@ -34,19 +76,24 @@ export class GroupController {
 
     @Authorized()
     @Put("/:id")
-    put(@CurrentUser() user: User, @Param("id") id: string, @Body() body: Group): Promise<Group> {
+    async update(@CurrentUser() user: User, @Param("id") id: string, @Body() body: UpdateGroupRequest): Promise<Group> {
+        const group = await Container.get(GroupService).findOne(id);
         // Check if person trying to edit is member of group
-        const index = body.participants.findIndex(participant => participant.username === user.username);
+        const index = group.participants.findIndex(participant => participant.username === user.username);
         if (index === -1) {
             throw new UnauthorizedError("You are not a participant of this group");
         }
 
-       return Container.get(GroupService).update(id, body);
+        const groupUpdate = new Group();
+        groupUpdate.name = body.name;
+        groupUpdate.description = body.description;
+
+       return Container.get(GroupService).update(id, groupUpdate);
     }
 
     @Authorized()
     @Put("/:id/bill")
-    async addBill(@CurrentUser() user: User, @Param("id") id: string, @Body() bill: Bill): Promise<Group> {
+    async addBill(@CurrentUser() user: User, @Param("id") id: string, @Body() body: AddBillRequest): Promise<Group> {
         // Check if person trying to edit is member of group
         const group = await Container.get(GroupService).findOne(id);
         const index = group.participants.findIndex(participant => participant.username === user.username);
@@ -54,19 +101,45 @@ export class GroupController {
             throw new UnauthorizedError("You are not a participant of this group");
         }
 
-       return Container.get(GroupService).addBill(user, id, bill);
+        const createdBill = new Bill();
+        createdBill.creditor = user;
+        createdBill.description = body.description;
+        createdBill.totalXrpDrops = body.totalXrpDrops;
+        createdBill.participants = [];
+        createdBill.weights = [];
+
+        if (body.participants.length !== body.weights.length) {
+            throw new BadRequestError("Participant length and weight length must match!");
+        }
+
+        for (let i = 0; i < body.participants.length; i++) {
+            const part = new User();
+            part.username = body.participants[i];
+            createdBill.participants.push(part);
+            const weight = new BillWeight();
+            weight.user = part;
+            weight.bill = createdBill;
+            weight.weight = body.weights[i];
+            createdBill.weights.push(weight);
+          }
+
+       return Container.get(GroupService).addBill(id, createdBill);
     }
 
     @Authorized()
-    @Put("/:id/:userid")
+    @Put("/:id/user/:userid")
     async addParticipant(@CurrentUser() user: User, @Param("id") id: string, @Param("userid") userId: string): Promise<Group> {
         const groupService = Container.get(GroupService);
         const group = await groupService.findOne(id);
         
-        // Check if person trying to edit is member of group
+        // Check if person trying to edit is member of group and new user not already part of the group
         const index = group.participants.findIndex(participant => participant.username === user.username);
+        const newUser = group.participants.findIndex(participant => participant.username === userId);
         if (index === -1) {
             throw new UnauthorizedError("You are not a participant of this group");
+        }
+        if (newUser !== -1) {
+            throw new BadRequestError("User you are trying to add is already part of this group");
         }
         return Container.get(GroupService).addParticipant(id, userId);
     }

--- a/src/controllers/TransactionRequestController.ts
+++ b/src/controllers/TransactionRequestController.ts
@@ -6,6 +6,7 @@ import { TransactionRequest } from "../models/TransactionRequest";
 import { LoggerService } from "../services/LoggerService";
 import { NotificationService } from '../services/NotificationService';
 import {IsNotEmpty, IsString, MaxLength} from "class-validator";
+import { GroupService } from "../services/GroupService";
 
 class PayTransactionRequestRequest {
     @IsString()
@@ -67,7 +68,11 @@ export class TransactionRequestController {
         if (await trService.validatePayment(tr)) {
             tr.paid = true;
             Container.get(NotificationService).sendPaymentReceivedNotification(tr.bill.creditor);
-            return Container.get(TransactionRequestService).update(body.id, tr);
+            const result = await Container.get(TransactionRequestService).update(body.id, tr);
+            if (tr.group !== undefined) {
+                await Container.get(GroupService).settlementPaid(tr);
+            }
+            return result;
         } else {
             throw new BadRequestError("Payment validation failed");
         }

--- a/src/controllers/TransactionRequestController.ts
+++ b/src/controllers/TransactionRequestController.ts
@@ -64,10 +64,10 @@ export class TransactionRequestController {
         let tr = new TransactionRequest();
         tr.transactionHash = body.transactionHash;
         await trService.update(body.id, tr);
-        tr = await trService.findOne(tr.id, {relations: ["bill"]});
+        tr = await trService.findOne(tr.id, {relations: ["bill", "group"]});
         if (await trService.validatePayment(tr)) {
             tr.paid = true;
-            Container.get(NotificationService).sendPaymentReceivedNotification(tr.bill.creditor);
+            Container.get(NotificationService).sendPaymentReceivedNotification(tr.creditor);
             const result = await Container.get(TransactionRequestService).update(body.id, tr);
             if (tr.group !== undefined) {
                 await Container.get(GroupService).settlementPaid(tr);

--- a/src/models/Group.ts
+++ b/src/models/Group.ts
@@ -2,6 +2,7 @@ import { Column, Entity, PrimaryGeneratedColumn, ManyToMany, JoinTable, OneToMan
 import { User } from './User';
 import { GroupBalance } from './GroupBalance';
 import { Bill } from './Bill';
+import { TransactionRequest } from './TransactionRequest';
 
 @Entity({ name: "groups" })
 export class Group {
@@ -18,6 +19,11 @@ export class Group {
         eager: true
     })
     public groupBalances: GroupBalance[];
+
+    @OneToMany(() => TransactionRequest, tr => tr.group, {
+        eager: true
+    })
+    public transactionRequests: TransactionRequest[];
 
     @ManyToMany(() => User, {
         eager: true

--- a/src/models/TransactionRequest.ts
+++ b/src/models/TransactionRequest.ts
@@ -2,6 +2,7 @@ import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, BeforeInsert, AfterL
 import { User } from './User';
 import { Bill } from './Bill';
 import { bigIntToNumber } from '../util/PostGresUtil';
+import { Group } from './Group';
 
 @Entity({ name: "transaction_requests" })
 export class TransactionRequest {
@@ -19,6 +20,16 @@ export class TransactionRequest {
         onDelete: "CASCADE"
     })
     public bill: Bill;
+
+    @ManyToOne(() => Group, group => group.transactionRequests, {
+        onDelete: "CASCADE"
+    })
+    public group: Group;
+
+    @ManyToOne(() => User, user => user.creditorOfRequests, {
+        eager: true
+    })
+    public creditor: User;
 
     @ManyToOne(() => User, user => user.transactionRequests, {
         eager: true

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -34,6 +34,9 @@ export class User {
     @OneToMany(() => GroupBalance, balance => balance.user)
     public groupBalances: GroupBalance[];
 
+    @OneToMany(() => TransactionRequest, tr => tr.creditor)
+    public creditorOfRequests: TransactionRequest[];
+
     @OneToMany(() => TransactionRequest, tr => tr.debtor)
     public transactionRequests: TransactionRequest[];
 

--- a/src/services/BillService.ts
+++ b/src/services/BillService.ts
@@ -81,6 +81,7 @@ export class BillService {
         for (let i = 0; i < bill.participants.length; i++) {
             const tr = new TransactionRequest();
             tr.bill = bill;
+            tr.creditor = bill.creditor;
             tr.debtor = bill.participants[i];
             const dropShare = Math.floor(bill.totalXrpDrops / totalWeight * bill.weights[i].weight);
             totalDistributed += dropShare;

--- a/src/services/BillService.ts
+++ b/src/services/BillService.ts
@@ -57,16 +57,18 @@ export class BillService {
         return this.billRepository.findOne({ id });
     }
 
-    public async create(bill: Bill): Promise<Bill> {
+    public async create(bill: Bill, createTransactionRequests = true): Promise<Bill> {
         this.log.info('Create a new bill => ', bill.toString());
         let newBill = await this.billRepository.save(bill);
         for (const weight of newBill.weights) {
             await this.billWeightRepository.save(weight);
         }
         newBill = await this.findOne(newBill.id);
-        const createdRequests = this.createTransactionRequests(newBill);
-        for (const tr of createdRequests) {
-            Container.get(TransactionRequestService).create(tr);
+        if (createTransactionRequests) {
+            const createdRequests = this.createTransactionRequests(newBill);
+            for (const tr of createdRequests) {
+                await Container.get(TransactionRequestService).create(tr);
+            }
         }
         return newBill;
     }

--- a/src/services/GroupService.ts
+++ b/src/services/GroupService.ts
@@ -160,7 +160,9 @@ export class GroupService {
         return result;
     }
 
-    public async settlementPaid(tr: TransactionRequest): Promise<void> {
+    public async settlementPaid(transaction: TransactionRequest): Promise<void> {
+        this.log.info("Received payment for group settlement");
+        const tr = await Container.get(TransactionRequestService).findOne(transaction.id, {relations: ["group"]});
         const group = await this.findOne(tr.group.id);
         const creditorBalance = group.groupBalances.find(b => b.user.username === tr.creditor.username);
         const debtorBalance = group.groupBalances.find(b => b.user.username === tr.debtor.username);

--- a/src/services/GroupService.ts
+++ b/src/services/GroupService.ts
@@ -118,6 +118,13 @@ export class GroupService {
 
     public async settleGroup(id: string): Promise<Group> {
         const group = await this.findOne(id);
+        // Check if all previous settlements are paid
+        for (const tr of group.transactionRequests) {
+            if (!tr.paid) {
+                throw new BadRequestError("Previous settlement not finished yet");
+            }
+        }
+
         const requests = this.createSettlementTransactionRequests(group.groupBalances);
         for (const tr of requests) {
             tr.group = group;

--- a/src/services/GroupService.ts
+++ b/src/services/GroupService.ts
@@ -8,6 +8,8 @@ import { GroupBalanceService } from './GroupBalanceService';
 import { GroupBalance } from '../models/GroupBalance';
 import { UserService } from './UserService';
 import { Bill } from '../models/Bill';
+import { BadRequestError } from 'routing-controllers';
+import { BillService } from './BillService';
 
 @Service()
 export class GroupService {
@@ -29,7 +31,7 @@ export class GroupService {
 
     public findOne(id: string): Promise<Group | undefined> {
         this.log.info('Find one group');
-        return this.groupRepository.findOne({ id });
+        return this.groupRepository.findOne({id});
     }
 
     public async create(grp: Group): Promise<Group> {
@@ -57,25 +59,59 @@ export class GroupService {
 
     public async addParticipant(id: string, username: string): Promise<Group> {
         const user = await Container.get(UserService).findOne(username);
-        const group = await this.findOne(id);
+        let group = await this.findOne(id);
         const balance = new GroupBalance();
         balance.balance = 0;
         balance.group = group;
         balance.user = user;
+        await Container.get(GroupBalanceService).create(balance);
+        group = await this.findOne(id);
         group.participants.push(user);
-        group.groupBalances.push(balance);
-        return this.update(id, group);
+        await this.update(id, group);
+        return this.findOne(id);
     }
 
-    public async addBill(user: User, groupId: string, bill: Bill): Promise<Group> {
+    public async addBill(groupId: string, bill: Bill): Promise<Group> {
+        this.log.info("Adding bill to group" + groupId);
         const group = await this.findOne(groupId);
-        const newBill = new Bill();
-        newBill.creditor = user;
-        newBill.description = bill.description;
-        newBill.participants = bill.participants;
-        newBill.totalXrpDrops = bill.totalXrpDrops;
-        group.bills.push(newBill);
-        return this.update(groupId, group);
+        
+        // Make sure all participants in bill are in the group
+        for (const p of bill.participants) {
+            if (group.participants.findIndex(part => part.username === p.username) === -1) {
+                throw new BadRequestError("Participant in bill is not in group");
+            }
+        }
+        bill.group = group;
+        const createdBill = await Container.get(BillService).create(bill, false);
+        group.bills.push(createdBill);
+        const updatedGroup = this.updateBalances(group, bill);
+        for (const b of updatedGroup.groupBalances) {
+            await Container.get(GroupBalanceService).update(b.id, b);
+        }
+        return this.findOne(groupId);
+    }
+
+    public updateBalances(group: Group, bill: Bill): Group {
+        // Add amount to creditor's balance
+        const creditorBalance = group.groupBalances.find(balance => balance.user.username === bill.creditor.username);
+        creditorBalance.balance += bill.totalXrpDrops;
+
+        // For every participant, deduct share from balance
+        let totalWeight = 0, totalDistributed = 0;
+        bill.weights.forEach(w => totalWeight += w.weight);
+        for (let i = 0; i < bill.participants.length; i++) {
+            const dropShare = Math.floor(bill.totalXrpDrops / totalWeight * bill.weights[i].weight);
+            totalDistributed += dropShare;
+            const participantBalance = group.groupBalances.find(balance => balance.user.username === bill.participants[i].username);
+            participantBalance.balance -= dropShare;
+        }
+
+        // Randomly distribute missing drops
+        for (let i = 0; i < bill.totalXrpDrops - totalDistributed; i++) {
+            const randomParticipant = bill.participants[Math.floor(Math.random() * bill.participants.length)].username;
+            group.groupBalances.find(balance => balance.user.username === randomParticipant).balance -= 1;
+        }
+        return group;
     }
 
     public async delete(id: string): Promise<void> {

--- a/src/services/TransactionRequestService.ts
+++ b/src/services/TransactionRequestService.ts
@@ -32,8 +32,6 @@ export class TransactionRequestService {
             return false;
         }
 
-        // Get the bill that corresponds to this payment, the bills is not eagerly loaded so this line ensures that the bill field is loaded
-        const bill = (await this.findOne(tr.id, {relations: ["bill", "bill.creditor"]})).bill;
         let payment;
         try {
             payment = await Container.get(RippleLibService).getPayment(tr.transactionHash);
@@ -43,7 +41,7 @@ export class TransactionRequestService {
         const balanceChanges = payment.outcome.balanceChanges;
         let foundPayment = false;
 
-        const creditorAddress = rippleKey.deriveAddress(bill.creditor.publickey);
+        const creditorAddress = rippleKey.deriveAddress(tr.creditor.publickey);
         // Loop through all addresses that had their balance changed
         for (const addr in balanceChanges) {
             // If address corresponds to the creditor's address, loop through the currencies and find XRP, validate if the value is equal to the totalXrp value

--- a/test/e2e/api/BillController.test.ts
+++ b/test/e2e/api/BillController.test.ts
@@ -3,7 +3,6 @@ import { fork, ChildProcess } from "child_process";
 import fetch from "node-fetch";
 import { plainToClass } from "class-transformer";
 import { AddBillRequest } from "../../../src/controllers/BillController";
-import { User } from "../../../src/models/User";
 import { deriveKeypair, sign } from "ripple-keypairs";
 import { Bill } from "../../../src/models/Bill";
 
@@ -41,10 +40,6 @@ test('create bill', async () => {
     const bill = new AddBillRequest();
     bill.description = "test bill";
     bill.totalXrpDrops = 100;
-    const alice = new User();
-    alice.username = "alice";
-    const bob = new User();
-    bob.username = "bob";
     bill.participants = ["alice", "bob"];
     // eslint-disable-next-line
     bill.weights = [1, 1];

--- a/test/e2e/api/GroupController.test.ts
+++ b/test/e2e/api/GroupController.test.ts
@@ -1,0 +1,201 @@
+import dotenv from "dotenv";
+import { fork, ChildProcess } from "child_process";
+import fetch from "node-fetch";
+import { plainToClass } from "class-transformer";
+import { AddGroupRequest } from "../../../src/controllers/GroupController";
+import { deriveKeypair, sign } from "ripple-keypairs";
+import { Group } from "../../../src/models/Group";
+import { AddBillRequest } from "../../../src/controllers/BillController";
+
+let child: ChildProcess;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+let bearer: string, createdGroup: Group, smallerGroup: Group;
+
+beforeAll(async () => {
+    dotenv.config();
+    // Run the server as a child process
+    child = fork("./dist/index.js");
+    // Sleep to wait for child process to start up
+    await sleep(4000);
+
+    // Get authentication
+    let derivationResult = null;
+    derivationResult = deriveKeypair(process.env.ALICE_SECRET);
+
+    const resp = await fetch("http://localhost:8080/api/login/challenge?username=alice");
+    const challenge = await resp.json();
+
+    const result = sign(challenge.challenge, derivationResult.privateKey);
+
+    const bearerStr = Buffer.from("alice" + ":" + result).toString('base64');
+    bearer = `bearer=${bearerStr};path=/;max-age=840;samesite=strict`;
+});
+
+// Tests depend on the groups created in this test
+test('create 2 groups', async () => {
+    const group = new AddGroupRequest();
+    group.name = "test";
+    group.description = "";
+    group.participants = ["alice", "bob"];
+    const res = await fetch('http://localhost:' + process.env.PORT + '/api/groups', {
+        method: 'post',
+         headers: {
+            cookie: bearer,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(group)
+    });
+    expect(res.status).toBe(200);
+    createdGroup = plainToClass(Group, await res.json());
+    expect(createdGroup.bills.length).toBe(0);
+    expect(createdGroup.name).toBe(group.name);
+    expect(createdGroup.groupBalances.length).toBe(2);
+    expect(createdGroup.participants.length).toBe(2);
+    createdGroup.groupBalances.forEach(b => {
+        expect(b.balance).toBe(0);
+    });
+
+    const group2 = new AddGroupRequest();
+    group2.name = "test";
+    group2.description = "";
+    group2.participants = ["alice"];
+    const res2 = await fetch('http://localhost:' + process.env.PORT + '/api/groups', {
+        method: 'post',
+         headers: {
+            cookie: bearer,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(group2)
+    });
+    expect(res2.status).toBe(200);
+    smallerGroup = plainToClass(Group, await res2.json());
+    expect(smallerGroup.bills.length).toBe(0);
+    expect(smallerGroup.name).toBe(group2.name);
+    expect(smallerGroup.groupBalances.length).toBe(1);
+    expect(smallerGroup.participants.length).toBe(1);
+    smallerGroup.groupBalances.forEach(b => {
+        expect(b.balance).toBe(0);
+    });
+});
+
+test('add two bills and check balances', async () => {
+    const bill = new AddBillRequest();
+    bill.description = "test bill";
+    bill.totalXrpDrops = 100;
+    bill.participants = ["alice", "bob"];
+    // eslint-disable-next-line
+    bill.weights = [1, 1];
+    const res = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + createdGroup.id + '/bill', {
+        method: 'put',
+         headers: {
+            cookie: bearer,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(bill)
+    });
+    expect(res.status).toBe(200);
+    const updatedGroup = plainToClass(Group, await res.json());
+    expect(updatedGroup.bills.length).toBe(1);
+    expect(updatedGroup.name).toBe(createdGroup.name);
+    expect(updatedGroup.groupBalances.length).toBe(2);
+    expect(updatedGroup.participants.length).toBe(2);
+    updatedGroup.groupBalances.forEach(b => {
+        if (b.user.username === "alice") {
+            expect(b.balance).toBe(50);
+        } else {
+            expect(b.balance).toBe(-50);
+        }
+    });
+    const res2 = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + createdGroup.id + '/bill', {
+        method: 'put',
+         headers: {
+            cookie: bearer,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(bill)
+    });
+    expect(res2.status).toBe(200);
+    const updatedGroup2 = plainToClass(Group, await res2.json());
+    expect(updatedGroup2.bills.length).toBe(2);
+    expect(updatedGroup2.name).toBe(createdGroup.name);
+    expect(updatedGroup2.groupBalances.length).toBe(2);
+    expect(updatedGroup2.participants.length).toBe(2);
+    updatedGroup2.groupBalances.forEach(b => {
+        if (b.user.username === "alice") {
+            expect(b.balance).toBe(100);
+        } else {
+            expect(b.balance).toBe(-100);
+        }
+    });
+});
+
+test('update group description and get the group', async () => {
+    const group = new Group();
+    group.name = createdGroup.name;
+    group.description = "we have description nao";
+    const update = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + createdGroup.id, {
+        method: 'put',
+         headers: {
+            cookie: bearer,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(group)
+    });
+    expect(update.status).toBe(200);
+    const res = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + createdGroup.id, {
+        method: 'get',
+         headers: {
+            cookie: bearer
+        }
+    });
+    expect(res.status).toBe(200);
+    const updatedGroup = plainToClass(Group, await res.json());
+    expect(updatedGroup.bills.length).toBe(2);
+    expect(updatedGroup.name).toBe(createdGroup.name);
+    expect(updatedGroup.description).toBe(group.description);
+    expect(updatedGroup.groupBalances.length).toBe(2);
+    expect(updatedGroup.participants.length).toBe(2);
+});
+
+test('add participant to group', async () => {
+    const fail = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + createdGroup.id + "/user/alice", {
+        method: 'put',
+         headers: {
+            cookie: bearer
+        }
+    });
+    expect(fail.status).toBe(400);
+
+    const update = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + smallerGroup.id + "/user/bob", {
+        method: 'put',
+         headers: {
+            cookie: bearer
+        }
+    });
+    expect(update.status).toBe(200);
+    const res = await fetch('http://localhost:' + process.env.PORT + '/api/groups/' + smallerGroup.id, {
+        method: 'get',
+         headers: {
+            cookie: bearer
+        }
+    });
+    expect(res.status).toBe(200);
+    const group = plainToClass(Group, await res.json());
+    expect(group.bills.length).toBe(0);
+    expect(group.name).toBe(smallerGroup.name);
+    expect(group.groupBalances.length).toBe(2);
+    expect(group.participants.length).toBe(2);
+    group.groupBalances.forEach(b => {
+        expect(b.balance).toBe(0);
+    });
+});
+
+afterAll(async () => {
+    child.kill();
+});

--- a/test/unit/balance_update.test.ts
+++ b/test/unit/balance_update.test.ts
@@ -1,0 +1,100 @@
+import { Bill } from "../../src/models/Bill";
+import { User } from "../../src/models/User";
+import { BillWeight } from "../../src/models/BillWeight";
+import { GroupService } from "../../src/services/GroupService";
+import { Group } from "../../src/models/Group";
+import { GroupBalance } from "../../src/models/GroupBalance";
+
+const users: User[] = [], weights: BillWeight[] = [], balances: GroupBalance[] = [];
+let group: Group, groupService: GroupService;
+
+beforeEach(() => {
+    group = new Group();
+    group.groupBalances = [];
+    for (let i = 0; i < 4; i++) {
+        users[i] = new User();
+        users[i].username = "user" + i;
+        weights[i] = new BillWeight();
+        weights[i].user = users[i];
+        weights[i].weight = 1;
+        balances[i] = new GroupBalance();
+        balances[i].balance = 0;
+        balances[i].group = group;
+        balances[i].user = users[i];
+        group.groupBalances.push(balances[i]);
+    }
+    group.participants = [users[0], users[1]];
+    groupService = new GroupService(undefined);
+});
+
+test('100 drops, 2 people, equal weights', () => {
+    const bill = new Bill();
+    bill.group = group;
+    bill.creditor = users[0];
+    bill.participants = [users[0], users[1]];
+    bill.totalXrpDrops = 100;
+    bill.weights = [weights[0], weights[1]];
+    const result = groupService.updateBalances(group, bill);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBe(50);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBe(-50);
+    let total = 0;
+    result.groupBalances.forEach(b => total += b.balance);
+    expect(total).toBe(0);
+});
+
+test('100 drops, 2 people, 2:1 weights', () => {
+    const bill = new Bill();
+    bill.group = group;
+    bill.creditor = users[0];
+    bill.participants = [users[0], users[1]];
+    bill.totalXrpDrops = 1000;
+    weights[1].weight = 2;
+    bill.weights = [weights[0], weights[1]];
+    const result = groupService.updateBalances(group, bill);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBeLessThanOrEqual(667);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBeGreaterThanOrEqual(666);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBeLessThanOrEqual(-666);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBeGreaterThanOrEqual(-667);
+    let total = 0;
+    result.groupBalances.forEach(b => total += b.balance);
+    expect(total).toBe(0);
+});
+
+test('100 drops, 3 people, equal weights', () => {
+    const bill = new Bill();
+    bill.group = group;
+    bill.creditor = users[0];
+    bill.participants = [users[0], users[1], users[2]];
+    bill.totalXrpDrops = 1000;
+    bill.weights = [weights[0], weights[1], weights[2]];
+    const result = groupService.updateBalances(group, bill);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBeLessThanOrEqual(667);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBeGreaterThanOrEqual(666);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBeLessThanOrEqual(-333);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBeGreaterThanOrEqual(-334);
+    expect(result.groupBalances.find(b => b.user.username === users[2].username).balance).toBeLessThanOrEqual(-333);
+    expect(result.groupBalances.find(b => b.user.username === users[2].username).balance).toBeGreaterThanOrEqual(-334);
+    let total = 0;
+    result.groupBalances.forEach(b => total += b.balance);
+    expect(total).toBe(0);
+});
+
+test('102 drops, 4 people, equal weights', () => {
+    const bill = new Bill();
+    bill.creditor = users[0];
+    bill.participants = users;
+    bill.totalXrpDrops = 102;
+    bill.weights = weights;
+    const result = groupService.updateBalances(group, bill);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBeLessThanOrEqual(77);
+    expect(result.groupBalances.find(b => b.user.username === users[0].username).balance).toBeGreaterThanOrEqual(75);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBeLessThanOrEqual(-25);
+    expect(result.groupBalances.find(b => b.user.username === users[1].username).balance).toBeGreaterThanOrEqual(-27);
+    expect(result.groupBalances.find(b => b.user.username === users[2].username).balance).toBeLessThanOrEqual(-25);
+    expect(result.groupBalances.find(b => b.user.username === users[2].username).balance).toBeGreaterThanOrEqual(-27);
+    expect(result.groupBalances.find(b => b.user.username === users[3].username).balance).toBeLessThanOrEqual(-25);
+    expect(result.groupBalances.find(b => b.user.username === users[3].username).balance).toBeGreaterThanOrEqual(-27);
+    let total = 0;
+    result.groupBalances.forEach(b => total += b.balance);
+    expect(total).toBe(0);
+});

--- a/test/unit/group_settlement.test.ts
+++ b/test/unit/group_settlement.test.ts
@@ -1,0 +1,56 @@
+import { User } from "../../src/models/User";
+import { GroupService } from "../../src/services/GroupService";
+import { GroupBalance } from "../../src/models/GroupBalance";
+import { TransactionRequest } from "../../src/models/TransactionRequest";
+
+const users: User[] = [], balances: GroupBalance[] = [];
+let groupService: GroupService;
+
+beforeEach(() => {
+    for (let i = 0; i < 4; i++) {
+        users[i] = new User();
+        users[i].username = "user" + i;
+        balances[i] = new GroupBalance();
+        balances[i].balance = 0;
+        balances[i].user = users[i];
+    }
+    groupService = new GroupService(undefined);
+});
+
+test('2 balances', () => {
+    balances[0].balance = 100;
+    balances[1].balance = -100;
+    const result: TransactionRequest[] = groupService.createSettlementTransactionRequests(balances);
+    expect(result.length).toBe(1);
+    expect(result[0].debtor.username).toBe(balances[1].user.username);
+    expect(result[0].creditor.username).toBe(balances[0].user.username);
+    expect(result[0].totalXrpDrops).toBe(100);
+});
+
+test('3 balances, 1 negative', () => {
+    balances[0].balance = 50;
+    balances[1].balance = 50;
+    balances[2].balance = -100;
+    const result: TransactionRequest[] = groupService.createSettlementTransactionRequests(balances);
+    expect(result.length).toBe(2);
+    for (const tr of result) {
+        expect(tr.debtor.username).toBe(balances[2].user.username);
+        expect(tr.creditor.username === balances[0].user.username 
+            || tr.creditor.username === balances[1].user.username).toBeTruthy();
+        expect(tr.totalXrpDrops).toBe(50);
+    }
+});
+
+test('3 balances, 2 negative', () => {
+    balances[0].balance = 100;
+    balances[1].balance = -50;
+    balances[2].balance = -50;
+    const result: TransactionRequest[] = groupService.createSettlementTransactionRequests(balances);
+    expect(result.length).toBe(2);
+    for (const tr of result) {
+        expect(tr.debtor.username === balances[1].user.username
+            || tr.debtor.username === balances[2].user.username).toBeTruthy();
+        expect(tr.creditor.username).toBe(balances[0].user.username);
+        expect(tr.totalXrpDrops).toBe(50);
+    }
+});


### PR DESCRIPTION
Implemented the missing groups functionality and added tests.

* Balances are now updated when bill is added.
* Bill can be settled, which creates transaction requests. This is unit-tested.
* Transaction requests created by settlements can be paid and the balances will be updated.
* New settlement can only be started when all previous transaction requests are paid.